### PR TITLE
Handle grpc_read_thread exit by always firing an event

### DIFF
--- a/mod_google_transcribe/google_glue_v1.cpp
+++ b/mod_google_transcribe/google_glue_v1.cpp
@@ -331,7 +331,7 @@ static void *SWITCH_THREAD_FUNC grpc_read_thread(switch_thread_t *thread, void *
     switch_core_session_t* session = switch_core_session_locate(cb->sessionId);
     if (session) {
       grpc::Status status = streamer->finish();
-      if (10 == status.error_code()) {
+      if (11 == status.error_code()) {
         if (std::string::npos != status.error_message().find("Exceeded maximum allowed stream duration")) {
           cb->responseHandler(session, "max_duration_exceeded", cb->bugname);
         }

--- a/mod_google_transcribe/google_glue_v2.cpp
+++ b/mod_google_transcribe/google_glue_v2.cpp
@@ -288,7 +288,7 @@ static void *SWITCH_THREAD_FUNC grpc_read_thread(switch_thread_t *thread, void *
       // TODO: This works on the same principle as that used in the v1 equivalent, in that we search for the textual
       // error message to determine whether the cause of the problem is the expiration of the session.
       // It would be better if we could find a more reliable way of detecting this.
-      if (11 == status.error_code()) {
+      if (10 == status.error_code()) {
         if (std::string::npos != status.error_message().find("Max duration of 5 minutes reached")) {
           cb->responseHandler(session, "max_duration_exceeded", cb->bugname);
         }


### PR DESCRIPTION
This PR is a suggestion for a solution to #26 . It fires the error event, containing the error code and error message returned by the call to `streamer->finish()`. Perhaps there are better or more appropriate events to fire in this case but this seemed to be the simplest solution.