### PR TITLE
mod audio fork cannot parse ws:<IP>/call path

### DIFF
--- a/mod_audio_fork/lws_glue.cpp
+++ b/mod_audio_fork/lws_glue.cpp
@@ -419,7 +419,7 @@ extern "C" {
     }
 
     std::string strHost(server + offset);
-    //- `([^/:]+)` captures the hostname/IP address.
+    //- `([^/:]+)` captures the hostname/IP address, match any character except in the set
     //- `:?([0-9]*)?` optionally captures a colon and the port number, if it's present.
     //- `(/.*)` captures everything else (the path).
     std::regex re("([^/:]+):?([0-9]*)?(/.*)?$");

--- a/mod_audio_fork/lws_glue.cpp
+++ b/mod_audio_fork/lws_glue.cpp
@@ -419,7 +419,7 @@ extern "C" {
     }
 
     std::string strHost(server + offset);
-    std::regex re("^(.+?):?(\\d+)?(/.*)?$");
+    std::regex re("([^/:]+):?([0-9]*)?(/.*)?$");
     std::smatch matches;
     if(std::regex_search(strHost, matches, re)) {
       /*

--- a/mod_audio_fork/lws_glue.cpp
+++ b/mod_audio_fork/lws_glue.cpp
@@ -419,6 +419,9 @@ extern "C" {
     }
 
     std::string strHost(server + offset);
+    //- `([^/:]+)` captures the hostname/IP address.
+    //- `:?([0-9]*)?` optionally captures a colon and the port number, if it's present.
+    //- `(/.*)` captures everything else (the path).
     std::regex re("([^/:]+):?([0-9]*)?(/.*)?$");
     std::smatch matches;
     if(std::regex_search(strHost, matches, re)) {


### PR DESCRIPTION
Issue:
url: ws://34.34.34.23/call-path, parsed host: 34.34.34., missing **23**
