### PR TITLE
mod_*_tts is not able to parse http response code if the protocol is hot HTTP/2

### DIFF
--- a/mod_deepgram_tts/deepgram_glue.cpp
+++ b/mod_deepgram_tts/deepgram_glue.cpp
@@ -522,7 +522,7 @@ static bool parseHeader(const std::string& str, std::string& header, std::string
     return true;
 }
 
-static int AudioProducerHttp::extract_response_code(const std::string& input) {
+static int extract_response_code(const std::string& input) {
   std::size_t space_pos = input.find(' ');
   if (space_pos == std::string::npos) {
     switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Invalid HTTP response format %s\n", input.c_str());

--- a/mod_deepgram_tts/deepgram_glue.cpp
+++ b/mod_deepgram_tts/deepgram_glue.cpp
@@ -522,9 +522,27 @@ static bool parseHeader(const std::string& str, std::string& header, std::string
     return true;
 }
 
+static int AudioProducerHttp::extract_response_code(const std::string& input) {
+  std::size_t space_pos = input.find(' ');
+  if (space_pos == std::string::npos) {
+    switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Invalid HTTP response format %s\n", input.c_str());
+    return 0;
+  }
+
+  std::size_t code_start_pos = space_pos + 1;
+  std::size_t code_end_pos = input.find(' ', code_start_pos);
+  if (code_end_pos == std::string::npos) {
+    code_end_pos = input.length();
+  }
+
+  std::string code_str = input.substr(code_start_pos, code_end_pos - code_start_pos);
+  int response_code = std::stoi(code_str);
+  return response_code;
+}
+
 static size_t header_callback(char *buffer, size_t size, size_t nitems, ConnInfo_t *conn) {
   size_t bytes_received = size * nitems;
-  const std::string prefix = "HTTP/2 ";
+  const std::string prefix = "HTTP/";
   deepgram_t* d = conn->deepgram;
   std::string header, value;
   std::string input(buffer, bytes_received);
@@ -533,11 +551,11 @@ static size_t header_callback(char *buffer, size_t size, size_t nitems, ConnInfo
     if (0 == header.compare("dg-request-id")) d->request_id = strdup(value.c_str());
   }
   else {
-    switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "recv header: %s\n", input.c_str());
+    switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "header_callback: %s\n", input.c_str());
     if (input.rfind(prefix, 0) == 0) {
       try {
-        d->response_code = std::stoi(input.substr(prefix.length()));
-        switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "parsed response code: %ld\n", d->response_code);
+        d->response_code = extract_response_code(input);
+        switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "header_callback: parsed response code: %ld\n", d->response_code);
       } catch (const std::invalid_argument& e) {
         switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "header_callback: invalid response code %s\n", input.substr(prefix.length()).c_str());
       }

--- a/mod_elevenlabs_tts/elevenlabs_glue.cpp
+++ b/mod_elevenlabs_tts/elevenlabs_glue.cpp
@@ -552,24 +552,6 @@ static size_t write_cb(void *ptr, size_t size, size_t nmemb, ConnInfo_t *conn) {
   return bytes_received;
 }
 
-static int AudioProducerHttp::extract_response_code(const std::string& input) {
-  std::size_t space_pos = input.find(' ');
-  if (space_pos == std::string::npos) {
-    switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Invalid HTTP response format %s\n", input.c_str());
-    return 0;
-  }
-
-  std::size_t code_start_pos = space_pos + 1;
-  std::size_t code_end_pos = input.find(' ', code_start_pos);
-  if (code_end_pos == std::string::npos) {
-    code_end_pos = input.length();
-  }
-
-  std::string code_str = input.substr(code_start_pos, code_end_pos - code_start_pos);
-  int response_code = std::stoi(code_str);
-  return response_code;
-}
-
 static int extract_response_code(const std::string& input) {
   std::size_t space_pos = input.find(' ');
   if (space_pos == std::string::npos) {

--- a/mod_elevenlabs_tts/elevenlabs_glue.cpp
+++ b/mod_elevenlabs_tts/elevenlabs_glue.cpp
@@ -552,9 +552,46 @@ static size_t write_cb(void *ptr, size_t size, size_t nmemb, ConnInfo_t *conn) {
   return bytes_received;
 }
 
+static int AudioProducerHttp::extract_response_code(const std::string& input) {
+  std::size_t space_pos = input.find(' ');
+  if (space_pos == std::string::npos) {
+    switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Invalid HTTP response format %s\n", input.c_str());
+    return 0;
+  }
+
+  std::size_t code_start_pos = space_pos + 1;
+  std::size_t code_end_pos = input.find(' ', code_start_pos);
+  if (code_end_pos == std::string::npos) {
+    code_end_pos = input.length();
+  }
+
+  std::string code_str = input.substr(code_start_pos, code_end_pos - code_start_pos);
+  int response_code = std::stoi(code_str);
+  return response_code;
+}
+
+static int extract_response_code(const std::string& input) {
+  std::size_t space_pos = input.find(' ');
+  if (space_pos == std::string::npos) {
+    switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Invalid HTTP response format %s\n", input.c_str());
+    return 0;
+  }
+
+  std::size_t code_start_pos = space_pos + 1;
+  std::size_t code_end_pos = input.find(' ', code_start_pos);
+  if (code_end_pos == std::string::npos) {
+    code_end_pos = input.length();
+  }
+
+  std::string code_str = input.substr(code_start_pos, code_end_pos - code_start_pos);
+  int response_code = std::stoi(code_str);
+  return response_code;
+}
+
+
 static size_t header_callback(char *buffer, size_t size, size_t nitems, ConnInfo_t *conn) {
   size_t bytes_received = size * nitems;
-  const std::string prefix = "HTTP/2 ";
+  const std::string prefix = "HTTP/ ";
   elevenlabs_t* el = conn->elevenlabs;
   std::string header, value;
   std::string input(buffer, bytes_received);
@@ -565,11 +602,11 @@ static size_t header_callback(char *buffer, size_t size, size_t nitems, ConnInfo
     else if (0 == header.compare("history-item-id")) el->history_item_id = strdup(value.c_str());
   }
   else {
-    switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "recv header: %s\n", input.c_str());
+    switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "header_callback: %s\n", input.c_str());
     if (input.rfind(prefix, 0) == 0) {
       try {
-        el->response_code = std::stoi(input.substr(prefix.length()));
-        switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "parsed response code: %ld\n", el->response_code);
+        el->response_code = extract_response_code(input);
+        switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "header_callback: parsed response code: %ld\n", el->response_code);
       } catch (const std::invalid_argument& e) {
         switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "header_callback: invalid response code %s\n", input.substr(prefix.length()).c_str());
       }

--- a/mod_playht_tts/playht_glue.cpp
+++ b/mod_playht_tts/playht_glue.cpp
@@ -541,9 +541,27 @@ static bool parseHeader(const std::string& str, std::string& header, std::string
     return true;
 }
 
+static int extract_response_code(const std::string& input) {
+  std::size_t space_pos = input.find(' ');
+  if (space_pos == std::string::npos) {
+    switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Invalid HTTP response format %s\n", input.c_str());
+    return 0;
+  }
+
+  std::size_t code_start_pos = space_pos + 1;
+  std::size_t code_end_pos = input.find(' ', code_start_pos);
+  if (code_end_pos == std::string::npos) {
+    code_end_pos = input.length();
+  }
+
+  std::string code_str = input.substr(code_start_pos, code_end_pos - code_start_pos);
+  int response_code = std::stoi(code_str);
+  return response_code;
+}
+
 static size_t header_callback(char *buffer, size_t size, size_t nitems, ConnInfo_t *conn) {
   size_t bytes_received = size * nitems;
-  const std::string prefix = "HTTP/2 ";
+  const std::string prefix = "HTTP/";
   playht_t* p = conn->playht;
   std::string header, value;
   std::string input(buffer, bytes_received);
@@ -553,11 +571,11 @@ static size_t header_callback(char *buffer, size_t size, size_t nitems, ConnInfo
     else if (0 == header.compare("x-request-id")) p->request_id = strdup(value.c_str());
   }
   else {
-    switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "recv header: %s\n", input.c_str());
+    switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "header_callback: %s\n", input.c_str());
     if (input.rfind(prefix, 0) == 0) {
       try {
-        p->response_code = std::stoi(input.substr(prefix.length()));
-        switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "parsed response code: %ld\n", p->response_code);
+        p->response_code = extract_response_code(input);
+        switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "header_callback: parsed response code: %ld\n", p->response_code);
       } catch (const std::invalid_argument& e) {
         switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "header_callback: invalid response code %s\n", input.substr(prefix.length()).c_str());
       }

--- a/mod_rimelabs_tts/rimelabs_glue.cpp
+++ b/mod_rimelabs_tts/rimelabs_glue.cpp
@@ -3,6 +3,7 @@
 #include <switch_json.h>
 #include <curl/curl.h>
 #include <cstdlib>
+#include <sstream>
 
 #include <boost/circular_buffer.hpp>
 #include <boost/thread.hpp>
@@ -522,9 +523,27 @@ static bool parseHeader(const std::string& str, std::string& header, std::string
     return true;
 }
 
+static int extract_response_code(const std::string& input) {
+  std::size_t space_pos = input.find(' ');
+  if (space_pos == std::string::npos) {
+    switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Invalid HTTP response format %s\n", input.c_str());
+    return 0;
+  }
+
+  std::size_t code_start_pos = space_pos + 1;
+  std::size_t code_end_pos = input.find(' ', code_start_pos);
+  if (code_end_pos == std::string::npos) {
+    code_end_pos = input.length();
+  }
+
+  std::string code_str = input.substr(code_start_pos, code_end_pos - code_start_pos);
+  int response_code = std::stoi(code_str);
+  return response_code;
+}
+
 static size_t header_callback(char *buffer, size_t size, size_t nitems, ConnInfo_t *conn) {
   size_t bytes_received = size * nitems;
-  const std::string prefix = "HTTP/2 ";
+  const std::string prefix = "HTTP/";
   rimelabs_t* d = conn->rimelabs;
   std::string header, value;
   std::string input(buffer, bytes_received);
@@ -533,11 +552,11 @@ static size_t header_callback(char *buffer, size_t size, size_t nitems, ConnInfo
     if (0 == header.compare("dg-request-id")) d->request_id = strdup(value.c_str());
   }
   else {
-    switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "recv header: %s\n", input.c_str());
+    switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "header_callback: %s\n", input.c_str());
     if (input.rfind(prefix, 0) == 0) {
       try {
-        d->response_code = std::stoi(input.substr(prefix.length()));
-        switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "parsed response code: %ld\n", d->response_code);
+        d->response_code = extract_response_code(input);
+        switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "header_callback: parsed response code: %ld\n", d->response_code);
       } catch (const std::invalid_argument& e) {
         switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "header_callback: invalid response code %s\n", input.substr(prefix.length()).c_str());
       }


### PR DESCRIPTION
mod_*_tts is not able to parse http response code if the protocol is hot HTTP/2