### PR TITLE
Add Error Code Check to Google V1 Implementation

### DIFF
--- a/mod_google_transcribe/google_glue_v1.cpp
+++ b/mod_google_transcribe/google_glue_v1.cpp
@@ -236,6 +236,7 @@ static void *SWITCH_THREAD_FUNC grpc_read_thread(switch_thread_t *thread, void *
       switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "grpc_read_thread: error %s (%d)\n", status.message().c_str(), status.code()) ;
       cJSON* json = cJSON_CreateObject();
       cJSON_AddStringToObject(json, "type", "error");
+      cJSON_AddStringToObject(json, "error_type", "stream_response");
       cJSON_AddStringToObject(json, "error", status.message().c_str());
       char* jsonString = cJSON_PrintUnformatted(json);
       cb->responseHandler(session, jsonString, cb->bugname);
@@ -342,6 +343,7 @@ static void *SWITCH_THREAD_FUNC grpc_read_thread(switch_thread_t *thread, void *
       else if (status.error_code() != 0)  {
         cJSON* json = cJSON_CreateObject();
         cJSON_AddStringToObject(json, "type", "error");
+        cJSON_AddStringToObject(json, "error_type", "stream_close");
         cJSON_AddItemToObject(json, "error_code", cJSON_CreateNumber(status.error_code()));
         cJSON_AddStringToObject(json, "error_message", status.error_message().c_str());
         char* jsonString = cJSON_PrintUnformatted(json);

--- a/mod_google_transcribe/google_glue_v1.cpp
+++ b/mod_google_transcribe/google_glue_v1.cpp
@@ -340,11 +340,11 @@ static void *SWITCH_THREAD_FUNC grpc_read_thread(switch_thread_t *thread, void *
           cb->responseHandler(session, "no_audio", cb->bugname);
         }
       }
-      else if (status.error_code() != 0)  {
+      else if (status.error_code() != 0) {
         cJSON* json = cJSON_CreateObject();
         cJSON_AddStringToObject(json, "type", "error");
-        cJSON_AddStringToObject(json, "error_type", "stream_close");
-        cJSON_AddItemToObject(json, "error_cause", cJSON_CreateNumber(status.error_code()));
+        cJSON_AddStringToObject(json, "error_cause", "stream_close");
+        cJSON_AddItemToObject(json, "error_code", cJSON_CreateNumber(status.error_code()));
         cJSON_AddStringToObject(json, "error_message", status.error_message().c_str());
         char* jsonString = cJSON_PrintUnformatted(json);
         cb->responseHandler(session, jsonString, cb->bugname);

--- a/mod_google_transcribe/google_glue_v1.cpp
+++ b/mod_google_transcribe/google_glue_v1.cpp
@@ -236,7 +236,7 @@ static void *SWITCH_THREAD_FUNC grpc_read_thread(switch_thread_t *thread, void *
       switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "grpc_read_thread: error %s (%d)\n", status.message().c_str(), status.code()) ;
       cJSON* json = cJSON_CreateObject();
       cJSON_AddStringToObject(json, "type", "error");
-      cJSON_AddStringToObject(json, "error_type", "stream_response");
+      cJSON_AddStringToObject(json, "error_cause", "stream_response");
       cJSON_AddStringToObject(json, "error", status.message().c_str());
       char* jsonString = cJSON_PrintUnformatted(json);
       cb->responseHandler(session, jsonString, cb->bugname);
@@ -344,7 +344,7 @@ static void *SWITCH_THREAD_FUNC grpc_read_thread(switch_thread_t *thread, void *
         cJSON* json = cJSON_CreateObject();
         cJSON_AddStringToObject(json, "type", "error");
         cJSON_AddStringToObject(json, "error_type", "stream_close");
-        cJSON_AddItemToObject(json, "error_code", cJSON_CreateNumber(status.error_code()));
+        cJSON_AddItemToObject(json, "error_cause", cJSON_CreateNumber(status.error_code()));
         cJSON_AddStringToObject(json, "error_message", status.error_message().c_str());
         char* jsonString = cJSON_PrintUnformatted(json);
         cb->responseHandler(session, jsonString, cb->bugname);

--- a/mod_google_transcribe/google_glue_v1.cpp
+++ b/mod_google_transcribe/google_glue_v1.cpp
@@ -339,7 +339,7 @@ static void *SWITCH_THREAD_FUNC grpc_read_thread(switch_thread_t *thread, void *
           cb->responseHandler(session, "no_audio", cb->bugname);
         }
       }
-      else {
+      else if (status.error_code() != 0)  {
         cJSON* json = cJSON_CreateObject();
         cJSON_AddStringToObject(json, "type", "error");
         cJSON_AddItemToObject(json, "error_code", cJSON_CreateNumber(status.error_code()));

--- a/mod_google_transcribe/google_glue_v2.cpp
+++ b/mod_google_transcribe/google_glue_v2.cpp
@@ -349,6 +349,7 @@ static void *SWITCH_THREAD_FUNC grpc_read_thread(switch_thread_t *thread, void *
       else if (status.error_code() != 0) {
         cJSON* json = cJSON_CreateObject();
         cJSON_AddStringToObject(json, "type", "error");
+        cJSON_AddStringToObject(json, "error_type", "stream_close");
         cJSON_AddItemToObject(json, "error_code", cJSON_CreateNumber(status.error_code()));
         cJSON_AddStringToObject(json, "error_message", status.error_message().c_str());
         char* jsonString = cJSON_PrintUnformatted(json);

--- a/mod_google_transcribe/google_glue_v2.cpp
+++ b/mod_google_transcribe/google_glue_v2.cpp
@@ -349,7 +349,7 @@ static void *SWITCH_THREAD_FUNC grpc_read_thread(switch_thread_t *thread, void *
       else if (status.error_code() != 0) {
         cJSON* json = cJSON_CreateObject();
         cJSON_AddStringToObject(json, "type", "error");
-        cJSON_AddStringToObject(json, "error_type", "stream_close");
+        cJSON_AddStringToObject(json, "error_cause", "stream_close");
         cJSON_AddItemToObject(json, "error_code", cJSON_CreateNumber(status.error_code()));
         cJSON_AddStringToObject(json, "error_message", status.error_message().c_str());
         char* jsonString = cJSON_PrintUnformatted(json);


### PR DESCRIPTION
Here I wanted to just add the check for the error code of 0 which is already in the V2 version of the library. However I noticed that the V1 code already generates an error event if the response from the stream itself is erroneous. In the V2 version of the library the response stream does not have this feature.

When I tested this I found that in cases where this response stream did contain an error, we also encountered the same error later in the function when the stream was closed and we query the `grpc` error code explicitly. I am not sure we really need to check the response for errors but perhaps there is a case where this is needed, and I just didn't find it.

So this part of the code is still there but I did add an extra field to the JSON object sent along with the event so that we know whether the error event originated from this response code or from the status code after the closing of the stream.