### PR TITLE
reset response when cached speech interface feeded new text

### DIFF
--- a/mod_azure_tts/mod_azure_tts.c
+++ b/mod_azure_tts/mod_azure_tts.c
@@ -82,6 +82,8 @@ static switch_status_t a_speech_feed_tts(switch_speech_handle_t *sh, char *text,
   a->draining = 0;
   a->reads = 0;
   a->flushed = 0;
+  a->response_code = 0;
+  a->err_msg = NULL;
 
   return azure_speech_feed_tts(a, text, flags);
 }

--- a/mod_deepgram_tts/mod_deepgram_tts.c
+++ b/mod_deepgram_tts/mod_deepgram_tts.c
@@ -84,6 +84,8 @@ static switch_status_t d_speech_feed_tts(switch_speech_handle_t *sh, char *text,
   deepgram_t *d = createOrRetrievePrivateData(sh);
   d->draining = 0;
   d->reads = 0;
+  d->response_code = 0;
+  d->err_msg = NULL;
 
   switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "d_speech_feed_tts\n");
 

--- a/mod_elevenlabs_tts/mod_elevenlabs_tts.c
+++ b/mod_elevenlabs_tts/mod_elevenlabs_tts.c
@@ -106,6 +106,8 @@ static switch_status_t ell_speech_feed_tts(switch_speech_handle_t *sh, char *tex
   elevenlabs_t *el = createOrRetrievePrivateData(sh);
   el->draining = 0;
   el->reads = 0;
+  el->response_code = 0;
+  el->err_msg = NULL;
   
   switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "ell_speech_feed_tts\n");
   

--- a/mod_playht_tts/mod_playht_tts.c
+++ b/mod_playht_tts/mod_playht_tts.c
@@ -99,6 +99,8 @@ static switch_status_t p_speech_feed_tts(switch_speech_handle_t *sh, char *text,
   playht_t *p = createOrRetrievePrivateData(sh);
   p->draining = 0;
   p->reads = 0;
+  p->response_code = 0;
+  p->err_msg = NULL;
 
   switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "p_speech_feed_tts\n");
 

--- a/mod_rimelabs_tts/mod_rimelabs_tts.c
+++ b/mod_rimelabs_tts/mod_rimelabs_tts.c
@@ -82,6 +82,8 @@ static switch_status_t d_speech_feed_tts(switch_speech_handle_t *sh, char *text,
   rimelabs_t *d = createOrRetrievePrivateData(sh);
   d->draining = 0;
   d->reads = 0;
+  d->response_code = 0;
+  d->err_msg = NULL;
 
   switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "d_speech_feed_tts\n");
 

--- a/mod_whisper_tts/mod_whisper_tts.c
+++ b/mod_whisper_tts/mod_whisper_tts.c
@@ -90,6 +90,8 @@ static switch_status_t w_speech_feed_tts(switch_speech_handle_t *sh, char *text,
   whisper_t *w = createOrRetrievePrivateData(sh);
   w->draining = 0;
   w->reads = 0;
+  w->response_code = 0;
+  w->err_msg = NULL;
 
   switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "w_speech_feed_tts\n");
 


### PR DESCRIPTION
If cached speech interface was failed from previous synthesis and received new text, the speech interface would stop read tts due to bad response_code and error message from previous synthesis