### PR TITLE
Support Play TTS 3.0

### DIFF
--- a/mod_playht_tts/mod_playht_tts.c
+++ b/mod_playht_tts/mod_playht_tts.c
@@ -27,7 +27,8 @@ static void clearPlayht(playht_t* p, int freeAll) {
   if (p->connect_time_ms) free(p->connect_time_ms);
   if (p->final_response_time_ms) free(p->final_response_time_ms);
   if (p->cache_filename) free(p->cache_filename);
-  
+  if (p->url) free(p->url);
+
 
   p->api_key = NULL;
   p->user_id = NULL;
@@ -48,6 +49,7 @@ static void clearPlayht(playht_t* p, int freeAll) {
   p->connect_time_ms = NULL;
   p->final_response_time_ms = NULL;
   p->cache_filename = NULL;
+  p->url = NULL;
 
   if (freeAll) {
     if (p->voice_name) free(p->voice_name);
@@ -58,7 +60,7 @@ static void clearPlayht(playht_t* p, int freeAll) {
 }
 
 static playht_t * createOrRetrievePrivateData(switch_speech_handle_t *sh) {
-  playht_t *p = (playht_t *) sh->private_info;  
+  playht_t *p = (playht_t *) sh->private_info;
   if (!p) {
     p = switch_core_alloc(sh->memory_pool, sizeof(*p));
   	sh->private_info = p;

--- a/mod_playht_tts/mod_playht_tts.h
+++ b/mod_playht_tts/mod_playht_tts.h
@@ -3,18 +3,28 @@
 
 #include <switch.h>
 typedef struct playht_data {
-  char *voice_name;
-  char *api_key;
+  /* authentication */
   char *user_id;
-  char *quality;
+  char *api_key;
+
+  /* required */
+  char *voice_name;
+
+  /* optional (else will choose defaults in backend) */
+  char *voice_engine;
   char *speed;
   char *seed;
   char *temperature;
-  char *voice_engine;
-  char *emotion;
+  char *top_p;
   char *voice_guidance;
   char *style_guidance;
   char *text_guidance;
+  char *repetition_penalty;
+  char *language; // Only applies to Play3.0 voice engine
+
+  /* DEPRECATED */
+  char *quality; // use sample rate to adjust quality
+  char *emotion;
 
   /* result data */
   long response_code;
@@ -37,5 +47,9 @@ typedef struct playht_data {
   void *circularBuffer;
   switch_mutex_t *mutex;
   FILE *file;
+
+  /* Play3.0 specific */
+  char *url;
+  int url_expires_at_ms;
 } playht_t;
 #endif


### PR DESCRIPTION
Let me know what is easiest for you as far as testing (testing it yourselves, giving me access to your test machine, or helping me spin up my own test setup).

The main difference for the 3.0 TTS model is that you now query an auth endpoint and receive an API URL and an expiration time. Let me know what you think of my approach to handling this. I added the url and expiration to the playht_t type. Once they are there, it won't query the auth endpoint again until within 30 seconds of expiration.

I also added some of our TTS options which weren't already in here. In particular, for the 3.0 model, it works best to pass the desired language (as a lowercase string i.e. `english`). This option is for 3.0 only; others I added work for both 2.0 and 3.0. I also reordered the TTS options a bit and marked a couple of them as deprecated. 

My editor "helpfully" removed some trailing whitespace, but I can remove this from the PR if you want.

I want to get your take on error checking for the TTS options. Only one of the options had an error check--speed was checked to ensure it is not 0.0. In fact, if you want an error check here, you should make sure speed is greater than 0.0. But if you want this error check here, do you also want them for other options? I would lean toward not checking them here and instead letting the API give you an error if something is invalid, in case limits ever change. For that reason I took out the speed != 0.0 check, but I can put it back.